### PR TITLE
Upgrade to v0.7.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A self-hosted dashboard that puts all your feeds in one place.
     Site monitor
 
 
-**Shipped version:** 0.7.4~ynh1
+**Shipped version:** 0.7.6~ynh1
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -36,7 +36,7 @@ A self-hosted dashboard that puts all your feeds in one place.
     Site monitor
 
 
-**Versión actual:** 0.7.4~ynh1
+**Versión actual:** 0.7.6~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -36,7 +36,7 @@ A self-hosted dashboard that puts all your feeds in one place.
     Site monitor
 
 
-**Paketatutako bertsioa:** 0.7.4~ynh1
+**Paketatutako bertsioa:** 0.7.6~ynh1
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Il NE doit PAS être modifié à la main.
 
 Tableau de bord auto-hébergé qui regroupe tous vos flux au même endroit.
 
-**Version incluse :** 0.7.4~ynh1
+**Version incluse :** 0.7.6~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -36,7 +36,7 @@ A self-hosted dashboard that puts all your feeds in one place.
     Site monitor
 
 
-**Versión proporcionada:** 0.7.4~ynh1
+**Versión proporcionada:** 0.7.6~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -36,7 +36,7 @@ A self-hosted dashboard that puts all your feeds in one place.
     Site monitor
 
 
-**Versi terkirim:** 0.7.4~ynh1
+**Versi terkirim:** 0.7.6~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -36,7 +36,7 @@ A self-hosted dashboard that puts all your feeds in one place.
     Site monitor
 
 
-**Geleverde versie:** 0.7.4~ynh1
+**Geleverde versie:** 0.7.6~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -36,7 +36,7 @@ A self-hosted dashboard that puts all your feeds in one place.
     Site monitor
 
 
-**Dostarczona wersja:** 0.7.4~ynh1
+**Dostarczona wersja:** 0.7.6~ynh1
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -36,7 +36,7 @@ A self-hosted dashboard that puts all your feeds in one place.
     Site monitor
 
 
-**Поставляемая версия:** 0.7.4~ynh1
+**Поставляемая версия:** 0.7.6~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -36,7 +36,7 @@ A self-hosted dashboard that puts all your feeds in one place.
     Site monitor
 
 
-**分发版本：** 0.7.4~ynh1
+**分发版本：** 0.7.6~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Glance"
 description.en = "Self-hosted dashboard that puts all your feeds in one place"
 description.fr = "Tableau de bord auto-hébergé qui regroupe tous vos flux au même endroit"
 
-version = "0.7.4~ynh1"
+version = "0.7.6~ynh1"
 
 maintainers = []
 
@@ -45,14 +45,14 @@ ram.runtime = "50M"
     [resources.sources.main]
     in_subdir = false
     extract   = true
-    amd64.url = "https://github.com/glanceapp/glance/releases/download/v0.7.4/glance-linux-amd64.tar.gz"
-    amd64.sha256 = "7d2317ee06b28bcc6c2860ab30b1c3e7b4c20b6e3e49f95768336f9350bbd179"
-    arm64.url = "https://github.com/glanceapp/glance/releases/download/v0.7.4/glance-linux-arm64.tar.gz"
-    arm64.sha256 = "a857d62346d065f7ff90925da4e2b141ad3a1953d35ff6a9b44632ae90dcc80f"
-    armhf.url = "https://github.com/glanceapp/glance/releases/download/v0.7.4/glance-linux-armv7.tar.gz"
-    armhf.sha256 = "5b00f436d215ab701be13767c267543505960e272a891392acd4ecedc96dcb07"
-    i386.url = "https://github.com/glanceapp/glance/releases/download/v0.7.4/glance-linux-386.tar.gz"
-    i386.sha256 = "37584ed3d0e083f654e00b41cf8518beb928bafd4b9fbf3c0f3c8784cb359533"
+    amd64.url = "https://github.com/glanceapp/glance/releases/download/v0.7.6/glance-linux-amd64.tar.gz"
+    amd64.sha256 = "e852d83bde0f33026da371f02c65c0d75c55f2ace2f635ed2ce92b5c23cbbb7c"
+    arm64.url = "https://github.com/glanceapp/glance/releases/download/v0.7.6/glance-linux-arm64.tar.gz"
+    arm64.sha256 = "686245e23775ad338df3a78c1d7dc2936634d3077b7caeed8bea6eec9c452a94"
+    armhf.url = "https://github.com/glanceapp/glance/releases/download/v0.7.6/glance-linux-armv7.tar.gz"
+    armhf.sha256 = "47f76be703becff4f66b5dcf3be031fa7addbca7b8549fa06df7ce68e707314c"
+    i386.url = "https://github.com/glanceapp/glance/releases/download/v0.7.6/glance-linux-386.tar.gz"
+    i386.sha256 = "02fc3c981fabed80b18d3c100d6a6a462b691ebcd80ed666150939cf1d5bec18"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.amd64 = "^glance-linux-amd64.tar.gz$"


### PR DESCRIPTION
Upgrade sources
- `main` v0.7.6: https://github.com/glanceapp/glance/releases/tag/v0.7.6

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
